### PR TITLE
feat: add CursorBench and Software Engineering Arena

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Also, a leaderboard should be included if only:
 | [Kaggle](https://www.kaggle.com/competitions) | Kaggle is one of the largest platforms for data science and machine learning competitions, covering a broad range of topics from image classification to NLP and predictive modeling. |
 | [nuScenes](https://www.nuscenes.org) | nuScenes enables researchers to study challenging urban driving situations using the full sensor suite of a real self-driving car, facilitating research in autonomous driving. |
 | [Robust Reading Competition](https://rrc.cvc.uab.es) | Robust Reading refers to the research area on interpreting written communication in unconstrained settings, with competitions focused on text recognition in real-world environments. |
+|[Software Engineering Arena](https://github.com/Software-Engineering-Arena) | Software Engineering Arena is an open-source initiative to transparently evaluate and track AI assistants across real-world software engineering tasks. |
 | [Tianchi](https://tianchi.aliyun.com/competition) | Tianchi, hosted by Alibaba, offers a range of AI competitions, particularly popular in Asia, with a focus on commerce, healthcare, and logistics. |
 
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Also, a leaderboard should be included if only:
 | [Big Code Models Leaderboard](https://huggingface.co/spaces/bigcode/bigcode-models-leaderboard) | Big Code Models Leaderboard is a platform to track and evaluate the performance of LLMs on code-related tasks. |
 | [BIRD](https://bird-bench.github.io) | BIRD is a benchmark to evaluate the performance of text-to-SQL parsing systems. |
 | [CanAiCode Leaderboard](https://huggingface.co/spaces/mike-ravkine/can-ai-code-results) | CanAiCode Leaderboard is a platform to evaluate the code generation capabilities of LLMs. |
+| [CursorBench](https://cursor-bench.github.io) | CursorBench is a benchmark to evaluate AI models' code generation and editing capabilities. |
 | [ClassEval](https://fudanselab-classeval.github.io/leaderboard.html) | ClassEval is a benchmark to evaluate LLMs on class-level code generation. |
 | [CodeApex](https://github.com/APEXLAB/CodeApex?tab=readme-ov-file#leaderboard) | CodeApex is a benchmark to evaluate LLMs' programming comprehension through multiple-choice questions and code generation with C++ algorithm problems. |
 | [CodeScope](https://haitianliu22.github.io/code-scope-benchmark/leaderboard.html) | CodeScope is a benchmark to evaluate LLM coding capabilities across 43 languages and 8 tasks, considering difficulty, efficiency, and length. |


### PR DESCRIPTION
This PR adds two new entries to the awesome leaderboard catalog:

- **CursorBench**: A benchmark for evaluating AI models' code generation and editing capabilities. Added to the Code section.
- **Software Engineering Arena**: An open-source initiative to transparently evaluate and track AI assistants across real-world software engineering tasks. Added to the Challenges section as an evaluation platform.

Both additions follow alphabetical ordering within their respective sections.