### PR TITLE
feat: add Software Engineering Arena

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Also, a leaderboard should be included if only:
 | [Kaggle](https://www.kaggle.com/competitions) | Kaggle is one of the largest platforms for data science and machine learning competitions, covering a broad range of topics from image classification to NLP and predictive modeling. |
 | [nuScenes](https://www.nuscenes.org) | nuScenes enables researchers to study challenging urban driving situations using the full sensor suite of a real self-driving car, facilitating research in autonomous driving. |
 | [Robust Reading Competition](https://rrc.cvc.uab.es) | Robust Reading refers to the research area on interpreting written communication in unconstrained settings, with competitions focused on text recognition in real-world environments. |
+| [Software Engineering Arena](https://github.com/Software-Engineering-Arena) | Software Engineering Arena is an open-source initiative to transparently evaluate and track AI assistants across real-world software engineering tasks. |
 | [Tianchi](https://tianchi.aliyun.com/competition) | Tianchi, hosted by Alibaba, offers a range of AI competitions, particularly popular in Asia, with a focus on commerce, healthcare, and logistics. |
 
 


### PR DESCRIPTION
This PR adds Software Engineering Arena, an open-source initiative to transparently evaluate and track AI assistants across real-world software engineering tasks, to the Challenges section of the README.

**Placement:** Added after 'Robust Reading Competition' (alphabetical order).