### PR TITLE
Add Hlido AI agent leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Also, a leaderboard should be included if only:
 | [EvoClaw](https://evo-claw.com/#leaderboard) | EvoClaw is a leaderboard for evaluating and ranking AI agents across benchmark tasks. |
 | [FlagEval](https://flageval.baai.ac.cn/#/leaderboard) | FlagEval is a comprehensive platform for evaluating foundation models. |
 | [Generative AI Leaderboards](https://accubits.com/generative-ai-models-leaderboard) | Generative AI Leaderboard ranks the top-performing generative AI models based on various metrics. |
+| [Hlido](https://hlido.eu/reviews) | Hlido ranks and reviews AI agents with Laddoo Scores, claim-vs-evidence tables, C2PA-signed proof artifacts, a public Hugging Face dataset, and a multi-tool MCP server. |
 | [Holistic Agent Leaderboard](https://hal.cs.princeton.edu/#leaderboards) | HAL is a standardized, cost-aware, and third-party leaderboard for evaluating agents. |
-| [Hlido](https://hlido.eu/reviews/) | Hlido ranks and reviews 329 AI agents with Laddoo Scores, claim-vs-evidence tables, C2PA-signed proof artifacts, a public Hugging Face dataset, and a 9-tool MCP server. |
 | [Holistic Evaluation of Language Models](https://crfm.stanford.edu/helm) | Holistic Evaluation of Language Models (HELM) is a reproducible and transparent framework for evaluating foundation models. |
 | [LLM Stats](https://llm-stats.com) | LLM Stats, the most comprehensive LLM leaderboard, benchmarks and compares API models using daily-updated, open-source community data on capability, price, speed, and context length. |
 | [Openrouter Leaderboard](https://openrouter.ai/rankings) | Openrouter Leaderboard offers a real-time comparison of language models based on normalized token usage for prompts and completions, updated frequently. |

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Also, a leaderboard should be included if only:
 | [FlagEval](https://flageval.baai.ac.cn/#/leaderboard) | FlagEval is a comprehensive platform for evaluating foundation models. |
 | [Generative AI Leaderboards](https://accubits.com/generative-ai-models-leaderboard) | Generative AI Leaderboard ranks the top-performing generative AI models based on various metrics. |
 | [Holistic Agent Leaderboard](https://hal.cs.princeton.edu/#leaderboards) | HAL is a standardized, cost-aware, and third-party leaderboard for evaluating agents. |
+| [Hlido](https://hlido.eu/reviews/) | Hlido ranks and reviews 329 AI agents with Laddoo Scores, claim-vs-evidence tables, C2PA-signed proof artifacts, a public Hugging Face dataset, and a 9-tool MCP server. |
 | [Holistic Evaluation of Language Models](https://crfm.stanford.edu/helm) | Holistic Evaluation of Language Models (HELM) is a reproducible and transparent framework for evaluating foundation models. |
 | [LLM Stats](https://llm-stats.com) | LLM Stats, the most comprehensive LLM leaderboard, benchmarks and compares API models using daily-updated, open-source community data on capability, price, speed, and context length. |
 | [Openrouter Leaderboard](https://openrouter.ai/rankings) | Openrouter Leaderboard offers a real-time comparison of language models based on normalized token usage for prompts and completions, updated frequently. |


### PR DESCRIPTION
Adds Hlido to the comprehensive leaderboard section. Hlido is a proof-backed AI agent review and ranking site with 329 public reviews, C2PA-signed evidence, a Hugging Face dataset, and MCP access for programmatic checks: https://hlido.eu. Disclosure: Hlido is submitted by its founder.